### PR TITLE
テスト時に使用するDBの設定を追加

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ libraryDependencies ++= Seq(
   guice,
   jdbc,
   evolutions,
+  "com.h2database" % "h2" % "1.4.197" % Test,
   "mysql" % "mysql-connector-java" % "6.0.5",
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
   "org.scalikejdbc" %% "scalikejdbc" % "3.3.0",

--- a/conf/test.conf
+++ b/conf/test.conf
@@ -1,3 +1,15 @@
 auth0.audience="https://metamor.api.com"
 auth0.domain="om-metamor.auth0.com"
 auth0.token="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9UZ3lOalJCTWtFeE9FUkdNVUV5UmtNME56QkdOa0kzTXpRNFJVVXlNRGN3UlVaRE1FRXlNUSJ9.eyJpc3MiOiJodHRwczovL29tLW1ldGFtb3IuYXV0aDAuY29tLyIsInN1YiI6ImJ3MXUxOTZqU1FNbWxFN2JkM1UzUWo1NmpPSzlNc2tKQGNsaWVudHMiLCJhdWQiOiJodHRwczovL21ldGFtb3IuYXBpLmNvbSIsImlhdCI6MTU0MzMwNDIxNiwiZXhwIjoxNTQ1ODk2MjE2LCJhenAiOiJidzF1MTk2alNRTW1sRTdiZDNVM1FqNTZqT0s5TXNrSiIsImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyJ9.jzjHBpk_00yIvOGITrhUJvGSDeIPW1kZw4duOcdRCtwFXzI5DP0y3IKv1s2ec2e85vGtFtWnMhajvGOneV2qssg_pnSka0h08vwADswAoojcYRuWyedKNos4DMI8GgIX-SFfwvhzzSUoofSi2aUhBSPwj0_wYxZfyOuIKbW6JFoqTbo0kRDhPzPOPnLllcf_edjs6xfMKVpu5VR_u0q_mI1pv4E6sFDlXzcoIzcOqP0xFgNV3yiEjORFVm-l5WupppiuDvDLh7fYfONNXfeywwvw6eJgnpa1M5yuDpOD-1276845jNvdTlHsnEY-K51Uq0NGtbrHQ1MWRYkpoU59Rw"
+
+db {
+  default.url="jdbc:h2:mem:play;MODE=MYSQL"
+  default.driver =org.h2.Driver
+  default.username = "root"
+  default.password = ""
+}
+
+play.evolutions.db.default {
+  autoApply = true
+  autoApplyDowns = true
+}

--- a/conf/test.conf
+++ b/conf/test.conf
@@ -13,3 +13,5 @@ play.evolutions.db.default {
   autoApply = true
   autoApplyDowns = true
 }
+
+play.modules.enabled += "scalikejdbc.PlayModule"

--- a/test/controllers/CreatorControllerSpec.scala
+++ b/test/controllers/CreatorControllerSpec.scala
@@ -7,6 +7,8 @@ import play.api.test.Helpers._
 import play.api.test._
 import akka.stream.Materializer
 import auth.{ AuthAction, AuthService }
+import mocks.MixInMockCreatorService
+import models.service.CreatorService
 import play.api.mvc.BodyParsers
 import play.api.{ Configuration, Environment }
 
@@ -22,23 +24,23 @@ class CreatorControllerSpec extends PlaySpec with GuiceOneAppPerSuite {
       new AuthService(config)
     )
 
-//  "success" should {
-//    "創作者作成" in {
-//      val request = FakeRequest(POST, "/creator")
-//        .withHeaders("Authorization" -> ("Bearer " + config.get[String]("auth0.token")))
-//        .withJsonBody(Json.parse("""{"displayId": "huga", "name": "ほげ"}"""))
-//
-//      val controller = new CreatorController(stubControllerComponents(), authAction)
-//      with MixInMockCreatorService {
-//        override val creatorService: CreatorService = mockCreatorService
-//      }
-//
-//      val result = call(controller.create(), request)
-//
-//      status(result) mustBe OK
-//      contentType(result) mustBe Some("application/json")
-//      contentAsString(result) must include("ok")
-//    }
-//  }
+  "success" should {
+    "創作者作成" in {
+      val request = FakeRequest(POST, "/creator")
+        .withHeaders("Authorization" -> ("Bearer " + config.get[String]("auth0.token")))
+        .withJsonBody(Json.parse("""{"displayId": "huga", "name": "ほげ"}"""))
+
+      val controller = new CreatorController(stubControllerComponents(), authAction)
+      with MixInMockCreatorService {
+        override val creatorService: CreatorService = mockCreatorService
+      }
+
+      val result = call(controller.create(), request)
+
+      status(result) mustBe OK
+      contentType(result) mustBe Some("application/json")
+      contentAsString(result) must include("ok")
+    }
+  }
 
 }


### PR DESCRIPTION
close #46 

## 概要
* テスト時にH2に接続するようにした

* Controller以外でServiceを使用する際、
Mockできないので結合テストをできる環境を作った 

## 技術的変更点概要
* H2の設定追加
* 創作者作成のバリデーションが通ることのテスト作成


## 今回保留した項目とTODOリスト
* 創作者作成、バリデーションに引っかかった場合のテストを書く

## その他
* ローカルでテスト回してみて通ればレビューおｋです