### PR TITLE
[update] openIdがない場合401を返すようにした

### DIFF
--- a/app/auth/AuthService.scala
+++ b/app/auth/AuthService.scala
@@ -63,6 +63,7 @@ class AuthService @Inject()(config: Configuration) {
   // issuer and audience fields.
   private val validateClaims = (claims: JwtClaim) =>
     if (claims.isValid(issuer, audience)) {
+      if (claims.subject.isEmpty) new Exception("OpenId not found")
       Success(claims)
     } else {
       Failure(new Exception("The JWT did not pass validation"))


### PR DESCRIPTION
close #70 

## 概要
* jsonのヘッダーにOpenIdがない場合401が返ってくる

## 技術的変更点概要
* authService内で検証するようにした
* Option型のままだけど、getで呼び出してもいいよ
