### PR TITLE
[update] 創作者の作成をできるようにした。

### DIFF
--- a/app/auth/AuthService.scala
+++ b/app/auth/AuthService.scala
@@ -63,6 +63,7 @@ class AuthService @Inject()(config: Configuration) {
   // issuer and audience fields.
   private val validateClaims = (claims: JwtClaim) =>
     if (claims.isValid(issuer, audience)) {
+      if (claims.subject.isEmpty) new Exception("OpenId not found")
       Success(claims)
     } else {
       Failure(new Exception("The JWT did not pass validation"))

--- a/app/models/entity/Account.scala
+++ b/app/models/entity/Account.scala
@@ -1,0 +1,24 @@
+package models.entity
+
+import java.time.ZonedDateTime
+
+import scalikejdbc.WrappedResultSet
+
+case class Account(
+    id: Long,
+    authId: String,
+    createdAt: ZonedDateTime,
+    updatedAt: ZonedDateTime
+)
+
+object Account {
+
+  def *(rs: WrappedResultSet): Account = {
+    Account(
+      rs.long("id"),
+      rs.string("auth_id"),
+      rs.zonedDateTime("created_at"),
+      rs.zonedDateTime("updated_at")
+    )
+  }
+}

--- a/app/models/entity/Creator.scala
+++ b/app/models/entity/Creator.scala
@@ -1,0 +1,15 @@
+package models.entity
+
+import java.time.ZonedDateTime
+
+case class Creator(
+    id: String,
+    accountId: Long,
+    name: String,
+    profile: String,
+    icon: String,
+    official: Boolean,
+    deletedAt: ZonedDateTime,
+    createdAt: ZonedDateTime,
+    updatedAt: ZonedDateTime
+)

--- a/app/models/repository/AccountRepository.scala
+++ b/app/models/repository/AccountRepository.scala
@@ -1,13 +1,24 @@
 package models.repository
 
+import models.entity.Account
 import scalikejdbc._
+
+import scala.util.Try
+import scala.util.control.Exception._
 
 trait AccountRepository {
   def exists(authId: String): Boolean
   def create(authId: String): Long
+
+  /**
+   * AuthIdからAccountを取得
+   * @param authId
+   * @return 該当するAccount
+   */
+  def findByAuthId(authId: String)(implicit s: DBSession): Try[Option[Account]]
 }
 
-trait UsesAccountRepository extends AccountRepository {
+trait UsesAccountRepository {
   val accountRepository: AccountRepository
 }
 
@@ -34,4 +45,18 @@ object AccountRepositoryImpl extends AccountRepository {
         """.updateAndReturnGeneratedKey().apply()
     }
   }
+
+  /**
+   * AuthIdからAccountを取得
+   *
+   * @param authId
+   * @return 該当するAccount
+   */
+  def findByAuthId(authId: String)(implicit s: DBSession): Try[Option[Account]] =
+    catching(classOf[Throwable]) withTry
+      sql"""
+          SELECT *
+          FROM accounts
+          WHERE auth_id = ${authId}
+      """.map(Account.*).first().apply()
 }

--- a/app/models/repository/CreatorRepository.scala
+++ b/app/models/repository/CreatorRepository.scala
@@ -2,8 +2,11 @@ package models.repository
 
 import scalikejdbc._
 
+import scala.util.Try
+import scala.util.control.Exception.catching
+
 trait CreatorRepository {
-  def create(id: String, name: String): Long
+  def create(id: String, name: String, accountId: Long)(implicit s: DBSession): Try[Long]
   def edit(id: Long, displayId: String, name: String, profile: String, icon: String): Long
   def existsById(id: String): Boolean
   def existsByAuthId(authId: String): Boolean
@@ -19,13 +22,12 @@ trait MixInCreatorRepository {
 
 object CreatorRepositoryImpl extends CreatorRepository {
 
-  def create(id: String, name: String): Long = {
-    DB autoCommit { implicit session =>
+  def create(id: String, name: String, accountId: Long)(implicit s: DBSession): Try[Long] = {
+    catching(classOf[Throwable]) withTry
       sql"""
-           insert into creators(id,name)
-           values (${id}, ${name})
-        """.updateAndReturnGeneratedKey().apply()
-    }
+           insert into creators(id,name,account_id)
+           values ($id, $name, $accountId)
+        """.update().apply()
   }
 
   def existsById(id: String): Boolean =

--- a/app/models/service/CreatorService.scala
+++ b/app/models/service/CreatorService.scala
@@ -7,7 +7,8 @@ import models.repository.{
   UsesCreatorRepository
 }
 import scalikejdbc._
-import scala.util.{ Failure, Success }
+
+import scala.util.{ Failure, Success, Try }
 
 trait CreatorService extends UsesCreatorRepository with UsesAccountRepository {
 
@@ -21,7 +22,8 @@ trait CreatorService extends UsesCreatorRepository with UsesAccountRepository {
     DB localTx { implicit session =>
       (for {
         accountOpt <- accountRepository.findByAuthId(authId)
-        creatorId <- creatorRepository.create(id, name, accountOpt.get.id)
+        account <- Try(accountOpt.get)
+        creatorId <- creatorRepository.create(id, name, account.id)
       } yield creatorId) match {
         case Failure(e) =>
           session.connection.rollback()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -28,4 +28,9 @@ scalikejdbc.global.loggingSQLAndTime.warningLogLevel=warn
 
 play.modules.enabled += "scalikejdbc.PlayModule"
 
+play.evolutions.db.default {
+  autoApply = true // 自動でUpsする
+  autoApplyDowns = true // 自動でDownsする
+}
+
 include classpath("auth0.conf")

--- a/test/mocks/ErrorAccountService.scala
+++ b/test/mocks/ErrorAccountService.scala
@@ -1,0 +1,32 @@
+package mocks
+
+import models.entity.Account
+import models.repository.AccountRepository
+import models.service.AccountService
+import scalikejdbc.DBSession
+
+import scala.util.Try
+
+object ErrorAccountRepositoryImpl extends AccountRepository {
+
+  def exists(authId: String): Boolean = true
+
+  def create(authId: String): Long = 1
+
+  /**
+   * AuthIdからAccountを取得
+   *
+   * @param authId
+   * @return 該当するAccount
+   */
+  def findByAuthId(authId: String)(implicit s: DBSession): Try[Option[Account]] =
+    Try(throw new Exception)
+}
+
+trait MixInErrorAccountRepository {
+  val accountRepository: AccountRepository = ErrorAccountRepositoryImpl
+}
+
+trait MixInErrorAccountService {
+  val mockAccountService: AccountService = new AccountService with MixInErrorAccountRepository
+}

--- a/test/mocks/ErrorCreatorService.scala
+++ b/test/mocks/ErrorCreatorService.scala
@@ -2,6 +2,9 @@ package mocks
 
 import models.repository.CreatorRepository
 import models.service.CreatorService
+import scalikejdbc.DBSession
+
+import scala.util.Try
 
 object ErrorCreatorRepositoryImpl extends CreatorRepository {
   def create(displayId: String, name: String): Long = throw new Exception
@@ -12,6 +15,9 @@ object ErrorCreatorRepositoryImpl extends CreatorRepository {
     throw new Exception
 
   def existsByAuthId(authId: String): Boolean = false
+
+  def create(id: String, name: String, accountId: Long)(implicit s: DBSession): Try[Long] =
+    Try(throw new Exception)
 }
 
 trait MixInErrorCreatorRepository {
@@ -20,4 +26,5 @@ trait MixInErrorCreatorRepository {
 
 trait MixInErrorCreatorService {
   val mockCreatorService: CreatorService = new CreatorService with MixInErrorCreatorRepository
+  with MixInErrorAccountRepository
 }

--- a/test/mocks/MockAccountService.scala
+++ b/test/mocks/MockAccountService.scala
@@ -1,13 +1,38 @@
 package mocks
 
+import java.time.ZonedDateTime
+
+import models.entity.Account
 import models.repository.AccountRepository
 import models.service.AccountService
+import scalikejdbc.DBSession
+
+import scala.util.Try
 
 object MockAccountRepositoryImpl extends AccountRepository {
 
   def exists(authId: String): Boolean = true
 
   def create(authId: String): Long = 1
+
+  /**
+   * AuthIdからAccountを取得
+   *
+   * @param authId
+   * @return 該当するAccount
+   */
+  def findByAuthId(authId: String)(implicit s: DBSession): Try[Option[Account]] =
+    Try(
+      Some(
+        Account(
+          1,
+          "hoge",
+          ZonedDateTime.now(),
+          ZonedDateTime.now()
+        )
+      )
+    )
+
 }
 
 trait MixInMockAccountRepository {

--- a/test/mocks/MockCreatorService.scala
+++ b/test/mocks/MockCreatorService.scala
@@ -2,6 +2,9 @@ package mocks
 
 import models.repository.CreatorRepository
 import models.service.CreatorService
+import scalikejdbc.DBSession
+
+import scala.util.Try
 
 object MockCreatorRepositoryImpl extends CreatorRepository {
   def create(displayId: String, name: String): Long = 1
@@ -11,6 +14,9 @@ object MockCreatorRepositoryImpl extends CreatorRepository {
   def edit(id: Long, displayId: String, name: String, profile: String, icon: String): Long = 1
 
   def existsByAuthId(authId: String): Boolean = true
+
+  def create(id: String, name: String, accountId: Long)(implicit s: DBSession): Try[Long] =
+    Try(1)
 }
 
 trait MixInMockCreatorRepository {
@@ -19,4 +25,5 @@ trait MixInMockCreatorRepository {
 
 trait MixInMockCreatorService {
   val mockCreatorService: CreatorService = new CreatorService with MixInMockCreatorRepository
+  with MixInMockAccountRepository
 }


### PR DESCRIPTION
close #68

## 概要
* creatorsテーブルにaccount_idをもたせたため、
creator作成を変更する必要があった


## 技術的変更点概要
* トランザクションを意識した実装に変更した
* evolutionsが自動でups,downsするようにした
## 今回保留した項目とTODOリスト
* 他のrepositoryとserviceも同じように実装を変えなくてはいけない

## その他
* CreatorServiceのcreateの実装を理解しておいてください
わからなければ聞いてください