### PR TITLE
[fix] 有効なワールド取得をコメントアウト

### DIFF
--- a/app/controllers/CharacterController.scala
+++ b/app/controllers/CharacterController.scala
@@ -1,14 +1,14 @@
 package controllers
 
-import javax.inject.{Inject, Singleton}
+import javax.inject.{ Inject, Singleton }
 import auth.AuthAction
-import forms.{CharacterCreateForm, CharacterDeleteForm}
+import forms.{ CharacterCreateForm, CharacterDeleteForm }
 import play.api.mvc._
 import io.circe.generic.auto._
 import io.circe.syntax._
 import play.api.libs.circe.Circe
 import models.service.MixInCharacterService
-import scalaz.{Failure, Success}
+import scalaz.{ Failure, Success }
 import scalaz.Scalaz._
 @Singleton
 class CharacterController @Inject()(cc: ControllerComponents, authAction: AuthAction)

--- a/app/controllers/WorldController.scala
+++ b/app/controllers/WorldController.scala
@@ -56,10 +56,10 @@ class WorldController @Inject()(cc: ControllerComponents, authAction: AuthAction
    * 開催中のワールド一覧の取得
    * @return
    */
-  def getEnable() = Action {
-    val holdWorlds = worldService.getEnable()
-    Ok((holdWorlds.asJson))
-  }
+//  def getEnable() = Action {
+//    val holdWorlds = worldService.getEnable()
+//    Ok((holdWorlds.asJson))
+//  }
 
   /**
    * ワールド参加

--- a/conf/routes
+++ b/conf/routes
@@ -10,7 +10,7 @@ GET     /creator/:creatorId/worlds        controllers.WorldController.getByCreat
 POST    /character                  controllers.CharacterController.create
 DELETE  /character                  controllers.CharacterController.delete
 GET     /world                      controllers.WorldController.getWorlds
-GET     /world/enable               controllers.WorldController.getEnable
+#GET     /world/enable               controllers.WorldController.getEnable
 POST    /world                      controllers.WorldController.create
 POST    /world/entry                controllers.WorldController.entry
 

--- a/test/controllers/WorldControllerSpec.scala
+++ b/test/controllers/WorldControllerSpec.scala
@@ -81,19 +81,19 @@ class WorldControllerSpec extends ControllerSpecBase {
       status(result) mustBe OK
     }
 
-    "開催中ワールド一覧取得" in {
-      val controller = new WorldController(stubControllerComponents(), authAction)
-      with MixInMockWorldService {
-        override val worldService: WorldService = mockWorldService
-      }
-      val result = controller.getEnable().apply(FakeRequest(GET, "/world"))
-
-      status(result) mustBe OK
-      contentType(result) mustBe Some("application/json")
-      contentAsString(result) must include("testName")
-      contentAsString(result) must include("testName2")
-
-    }
+//    "開催中ワールド一覧取得" in {
+//      val controller = new WorldController(stubControllerComponents(), authAction)
+//      with MixInMockWorldService {
+//        override val worldService: WorldService = mockWorldService
+//      }
+//      val result = controller.getEnable().apply(FakeRequest(GET, "/world"))
+//
+//      status(result) mustBe OK
+//      contentType(result) mustBe Some("application/json")
+//      contentAsString(result) must include("testName")
+//      contentAsString(result) must include("testName2")
+//
+//    }
 
     "他の創作者のワールド確認" in {
       val request = FakeRequest(GET, "/creator/:displayId/worlds")


### PR DESCRIPTION
close #91

## 概要
* /world/enableをコメントアウト
* コントローラーとテストもコメントアウト
## 技術的変更点概要
* /world/:idでworld詳細を取得したかった
* /worldの検索機能で有効なワールド取得は実装しようと思った

