### PR TITLE
[add] 創作者を1件取得する機能

### DIFF
--- a/app/controllers/CreatorController.scala
+++ b/app/controllers/CreatorController.scala
@@ -47,6 +47,22 @@ class CreatorController @Inject()(cc: ControllerComponents, authAction: AuthActi
     }
   }
 
+  /**
+   * 創作者を1件取得する
+   * @param id 創作者id
+   * @return Creator
+   */
+  def find(id: String) = Action {
+    creatorService.find(id) match {
+      case Left(e) => BadGateway
+      case Right(s) =>
+        s match {
+          case None    => NotFound
+          case Some(s) => Ok(s.asJson)
+        }
+    }
+  }
+
   def edit(): Action[CreatorEditForm] = authAction(circe.json[CreatorEditForm]) {
     implicit request =>
       creatorService.edit(

--- a/app/models/entity/Creator.scala
+++ b/app/models/entity/Creator.scala
@@ -2,14 +2,33 @@ package models.entity
 
 import java.time.ZonedDateTime
 
+import scalikejdbc.WrappedResultSet
+
+object Creator {
+
+  def *(rs: WrappedResultSet): Creator = {
+    Creator(
+      rs.string("id"),
+      rs.long("account_id"),
+      rs.string("name"),
+      rs.stringOpt("profile"),
+      rs.stringOpt("icon"),
+      rs.boolean("official"),
+      rs.zonedDateTimeOpt("deleted_at"),
+      rs.zonedDateTime("created_at"),
+      rs.zonedDateTime("updated_at")
+    )
+  }
+}
+
 case class Creator(
     id: String,
     accountId: Long,
     name: String,
-    profile: String,
-    icon: String,
+    profile: Option[String],
+    icon: Option[String],
     official: Boolean,
-    deletedAt: ZonedDateTime,
+    deletedAt: Option[ZonedDateTime],
     createdAt: ZonedDateTime,
     updatedAt: ZonedDateTime
 )

--- a/app/models/repository/CreatorRepository.scala
+++ b/app/models/repository/CreatorRepository.scala
@@ -1,5 +1,6 @@
 package models.repository
 
+import models.entity.Creator
 import scalikejdbc._
 
 import scala.util.Try
@@ -7,6 +8,13 @@ import scala.util.control.Exception.catching
 
 trait CreatorRepository {
   def create(id: String, name: String, accountId: Long)(implicit s: DBSession): Try[Long]
+
+  /**
+   * 創作者を1件取得
+   * @param id
+   */
+  def find(id: String)(implicit s: DBSession): Try[Option[Creator]]
+
   def edit(id: Long, displayId: String, name: String, profile: String, icon: String): Long
   def existsById(id: String): Boolean
   def existsByAuthId(authId: String): Boolean
@@ -29,6 +37,19 @@ object CreatorRepositoryImpl extends CreatorRepository {
            values ($id, $name, $accountId)
         """.update().apply()
   }
+
+  /**
+   * 創作者を1件取得
+   *
+   * @param id
+   */
+  def find(id: String)(implicit s: DBSession): Try[Option[Creator]] =
+    catching(classOf[Throwable]) withTry
+      sql"""
+            SELECT *
+            FROM creators
+            WHERE id = $id
+        """.map(Creator.*).single().apply()
 
   def existsById(id: String): Boolean =
     DB readOnly { implicit session =>

--- a/app/models/service/CreatorService.scala
+++ b/app/models/service/CreatorService.scala
@@ -1,5 +1,6 @@
 package models.service
 
+import models.entity.Creator
 import models.repository.{
   MixInAccountRepository,
   MixInCreatorRepository,
@@ -29,6 +30,19 @@ trait CreatorService extends UsesCreatorRepository with UsesAccountRepository {
     } match {
       case Failure(e) => Left(e)
       case Success(s) => Right(s)
+    }
+
+  /**
+   * 創作者IDより創作者を取得
+   * @param id
+   * @return
+   */
+  def find(id: String): Either[Throwable, Option[Creator]] =
+    DB readOnly { implicit session =>
+      creatorRepository.find(id) match {
+        case Failure(e) => Left(e)
+        case Success(s) => Right(s)
+      }
     }
 
   /**

--- a/conf/db/fixtures/default/account.sql
+++ b/conf/db/fixtures/default/account.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+insert into accounts (auth_id) values ('bw1u196jSQMmlE7bd3U3Qj56jOK9MskJ@clients');
+
+# --- !Downs
+delete from accounts;

--- a/conf/db/fixtures/default/creator.sql
+++ b/conf/db/fixtures/default/creator.sql
@@ -1,0 +1,5 @@
+# --- !Ups
+insert into creators(account_id,id,name) values (1,'hoge','huga');
+
+# --- !Downs
+delete from creators;

--- a/conf/routes
+++ b/conf/routes
@@ -6,11 +6,12 @@
 # An example controller showing a sample home page
 POST    /creator                    controllers.CreatorController.create
 PUT     /creator                    controllers.CreatorController.edit
+GET     /creator/:id                    controllers.CreatorController.find(id: String)
 GET     /creator/:creatorId/worlds        controllers.WorldController.getByCreatorId(creatorId: String)
 POST    /character                  controllers.CharacterController.create
 DELETE  /character                  controllers.CharacterController.delete
 
-GET    /character/:characterId/world/:worldId   controllers.StatusController.get(characterId: String, worldId: Long)
+GET     /character/:characterId/world/:worldId   controllers.StatusController.get(characterId: String, worldId: Long)
 POST    /character/:characterId/world/:worldId   controllers.StatusController.create(characterId: String, worldId: Long)
 
 GET     /world                      controllers.WorldController.getWorlds

--- a/test/controllers/CreatorControllerSpec.scala
+++ b/test/controllers/CreatorControllerSpec.scala
@@ -1,28 +1,19 @@
 package controllers
 
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import play.api.test._
 import mocks.MixInMockCreatorService
 import models.service.CreatorService
-
 import scalikejdbc._
-import scalikejdbc.scalatest.AutoRollback
-import org.scalatest.fixture.FlatSpec
 
 class CreatorControllerSpec extends ControllerSpecBase {
 
-  trait AutoRollbackWithFixture extends FlatSpec with AutoRollback {
-
-    val authId = config.get[String]("auth0.subject")
-
-    override def fixture(implicit session: DBSession) {
-      sql"""
-            insert into accounts (auth_id) values (${authId})
-      """.update().apply()
-
-    }
-  }
+  override def fakeApplication() =
+    new GuiceApplicationBuilder()
+      .configure(Map("db.default.fixtures.test" -> List("account.sql", "creator.sql")))
+      .build()
 
   "success" should {
 
@@ -43,10 +34,26 @@ class CreatorControllerSpec extends ControllerSpecBase {
       contentAsString(result) must include("ok")
     }
 
-    // DBのロールバック方法がわからないので「存在する場合」より先に検証
-    "創作者が存在するか確認 存在しない場合" in new AutoRollbackWithFixture {
-      DB autoCommit { implicit session =>
-        fixture
+    "創作者が存在するか確認 存在する場合" in {
+
+      val request = FakeRequest(GET, "/creator/validate/exists")
+        .withHeaders("Authorization" -> ("Bearer " + config.get[String]("auth0.token")))
+
+      val controller = new CreatorController(stubControllerComponents(), authAction)
+      val result = call(controller.exists(), request)
+
+      status(result) mustBe OK
+      contentType(result) mustBe Some("application/json")
+      contentAsString(result) must include("true")
+    }
+
+    "創作者が存在するか確認 存在しない場合" in {
+
+      // 存在しない場合をテストしたいので創作者を削除する
+      DB autoCommit { implicit s =>
+        sql"""
+              DELETE FROM creators;
+           """.update().apply()
       }
 
       val request = FakeRequest(GET, "/creator/validate/exists")
@@ -60,9 +67,13 @@ class CreatorControllerSpec extends ControllerSpecBase {
       contentAsString(result) must include("false")
     }
 
-    "創作者作成" in new AutoRollbackWithFixture {
+    "創作者作成" in {
+
+      // 創作者が存在すると作成できないため削除
       DB autoCommit { implicit s =>
-        fixture
+        sql"""
+              DELETE FROM creators;
+           """.update().apply()
       }
 
       val request = FakeRequest(POST, "/creator")
@@ -77,36 +88,6 @@ class CreatorControllerSpec extends ControllerSpecBase {
       contentType(result) mustBe Some("application/json")
       contentAsString(result) must include("creatorId")
       contentAsString(result) must include("huga")
-    }
-
-    "創作者が存在するか確認 存在する場合" in new AutoRollbackWithFixture {
-
-      // なぜかロールバックされない
-      override def fixture(implicit session: FixtureParam): Unit = {
-        sql"""
-            insert into accounts (auth_id) values (${authId})
-          """.update().apply()
-
-        sql"""
-            insert into creators(account_id,id,name)
-            values (1,'hoge','huga')
-        """.update().apply()
-
-      }
-
-      DB autoCommit { implicit session =>
-        fixture
-      }
-
-      val request = FakeRequest(GET, "/creator/validate/exists")
-        .withHeaders("Authorization" -> ("Bearer " + config.get[String]("auth0.token")))
-
-      val controller = new CreatorController(stubControllerComponents(), authAction)
-      val result = call(controller.exists(), request)
-
-      status(result) mustBe OK
-      contentType(result) mustBe Some("application/json")
-      contentAsString(result) must include("true")
     }
 
   }

--- a/test/controllers/CreatorControllerSpec.scala
+++ b/test/controllers/CreatorControllerSpec.scala
@@ -17,6 +17,32 @@ class CreatorControllerSpec extends ControllerSpecBase {
 
   "success" should {
 
+    "創作者取得" in {
+
+      val request = FakeRequest(GET, "/creator/hoge")
+        .withHeaders("Authorization" -> ("Bearer " + config.get[String]("auth0.token")))
+
+      val controller = new CreatorController(stubControllerComponents(), authAction)
+      val result = call(controller.find("hoge"), request)
+
+      status(result) mustBe OK
+      contentType(result) mustBe Some("application/json")
+      contentAsString(result) must include("hoge")
+      contentAsString(result) must include("huga")
+
+    }
+
+    "創作者取得 存在しない場合" in {
+
+      val request = FakeRequest(GET, "/creator/inaiyo")
+        .withHeaders("Authorization" -> ("Bearer " + config.get[String]("auth0.token")))
+
+      val controller = new CreatorController(stubControllerComponents(), authAction)
+      val result = call(controller.find("inaiyo"), request)
+
+      status(result) mustBe NOT_FOUND
+    }
+
     "創作者編集" in {
       val request = FakeRequest(PUT, "/creator")
         .withHeaders("Authorization" -> ("Bearer " + config.get[String]("auth0.token")))

--- a/test/mocks/ErrorCreatorService.scala
+++ b/test/mocks/ErrorCreatorService.scala
@@ -1,5 +1,6 @@
 package mocks
 
+import models.entity.Creator
 import models.repository.CreatorRepository
 import models.service.CreatorService
 import scalikejdbc.DBSession
@@ -8,6 +9,13 @@ import scala.util.Try
 
 object ErrorCreatorRepositoryImpl extends CreatorRepository {
   def create(displayId: String, name: String): Long = throw new Exception
+
+  /**
+   * 創作者を1件取得
+   *
+   * @param id
+   */
+  def find(id: String)(implicit s: DBSession): Try[Option[Creator]] = Try(throw new Exception)
 
   def existsById(id: String): Boolean = false
 
@@ -18,6 +26,7 @@ object ErrorCreatorRepositoryImpl extends CreatorRepository {
 
   def create(id: String, name: String, accountId: Long)(implicit s: DBSession): Try[Long] =
     Try(throw new Exception)
+
 }
 
 trait MixInErrorCreatorRepository {

--- a/test/mocks/MockCreatorService.scala
+++ b/test/mocks/MockCreatorService.scala
@@ -1,5 +1,8 @@
 package mocks
 
+import java.time.ZonedDateTime
+
+import models.entity.Creator
 import models.repository.CreatorRepository
 import models.service.CreatorService
 import scalikejdbc.DBSession
@@ -9,6 +12,26 @@ import scala.util.Try
 object MockCreatorRepositoryImpl extends CreatorRepository {
   def create(displayId: String, name: String): Long = 1
 
+  /**
+   * 創作者を1件取得
+   *
+   * @param id
+   */
+  def find(id: String)(implicit s: DBSession): Try[Option[Creator]] =
+    Try(
+      Some(
+        Creator(
+          "hoge",
+          1,
+          "huga",
+          None,
+          None,
+          false,
+          None,
+          ZonedDateTime.now(),
+          ZonedDateTime.now()
+        )))
+
   def existsById(id: String): Boolean = true
 
   def edit(id: Long, displayId: String, name: String, profile: String, icon: String): Long = 1
@@ -17,6 +40,7 @@ object MockCreatorRepositoryImpl extends CreatorRepository {
 
   def create(id: String, name: String, accountId: Long)(implicit s: DBSession): Try[Long] =
     Try(1)
+
 }
 
 trait MixInMockCreatorRepository {


### PR DESCRIPTION
close #99 

## 概要
* /creator/:id
上記にリクエストした際、
創作者のデータを取得できるようにした

## 技術的変更点概要

* CreatorControllerSpecのテストをscalikejdbc-play-fixtureを使用したものにした
