### PR TITLE
[update] 投稿を取得する順番を、作成日順に変更

### DIFF
--- a/app/models/repository/StatusRepository.scala
+++ b/app/models/repository/StatusRepository.scala
@@ -134,7 +134,7 @@ object StatusRepositoryImpl extends StatusRepository {
             JOIN characters ch on s.character_id = ch.id
             JOIN creators cr on ch.creator_id = cr.id
             WHERE world_id = ${worldId}
-            ORDER BY created_at DESC
+            ORDER BY created_at
       """.map(Status.*).list.apply()
 
 }


### PR DESCRIPTION
close #119

## 概要
* 投稿を取得する順番を、作成日順に変更

## 技術的変更点概要
* 逆の順番になっていたので修正


## 今回保留した項目とTODOリスト
* 投稿のページングや差分を取得する機能

