### PR TITLE
[update]投稿を20個ずつ取得するように変更

### DIFF
--- a/app/controllers/StatusController.scala
+++ b/app/controllers/StatusController.scala
@@ -53,8 +53,8 @@ class StatusController @Inject()(cc: ControllerComponents, authAction: AuthActio
     * 投稿を複数取得する
     * @return List[Status]
     */
-  def get(id: Long) = Action {
-    statusService.getByWorldId(id) match {
+  def get(id: Long, line: Long) = Action {
+    statusService.getByWorldId(id, line) match {
       case Left(e)  => BadGateway
       case Right(s) => Ok(s.asJson)
     }

--- a/app/models/repository/StatusRepository.scala
+++ b/app/models/repository/StatusRepository.scala
@@ -44,7 +44,7 @@ trait StatusRepository {
     * 投稿を複数取得
     * @param s
     */
-  def getByWorldId(worldId: Long)(implicit s: DBSession): Try[List[Status]]
+  def getByWorldId(worldId: Long, line: Long)(implicit s: DBSession): Try[List[Status]]
 
   /**
     * キャラクター別に投稿を取得
@@ -119,7 +119,7 @@ object StatusRepositoryImpl extends StatusRepository {
     *
     * @param s
     */
-  def getByWorldId(worldId: Long)(implicit s: DBSession): Try[List[Status]] =
+  def getByWorldId(worldId: Long, line: Long)(implicit s: DBSession): Try[List[Status]] =
     catching(classOf[Throwable]) withTry
       sql"""
             SELECT s.*,
@@ -143,6 +143,7 @@ object StatusRepositoryImpl extends StatusRepository {
             JOIN creators cr on ch.creator_id = cr.id
             WHERE world_id = ${worldId}
             ORDER BY created_at
+            LIMIT ${line * 20 - 20}, 20
       """.map(Status.*).list.apply()
 
   def getByCharacterId(worldId: Long, characterId: String)(

--- a/app/models/service/StatusService.scala
+++ b/app/models/service/StatusService.scala
@@ -48,9 +48,9 @@ trait StatusService extends UsesStatusRepository {
     * 投稿を複数取得
     * @return
     */
-  def getByWorldId(worldId: Long): Either[Throwable, List[Status]] =
+  def getByWorldId(worldId: Long, line: Long): Either[Throwable, List[Status]] =
     DB readOnly { implicit session =>
-      statusRepository.getByWorldId(worldId) match {
+      statusRepository.getByWorldId(worldId, line: Long) match {
         case Failure(e) => Left(e)
         case Success(s) => Right(s)
       }

--- a/conf/db/fixtures/default/status.sql
+++ b/conf/db/fixtures/default/status.sql
@@ -1,15 +1,30 @@
 # --- !Ups
-insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, 'てきすと1');
-insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, 'てきすと2');
-insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, 'てきすと3');
-insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, 'てきすと4');
-insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, 'てきすと5');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと1');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと2');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと3');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと4');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと5');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと6');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと7');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと8');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと9');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと10');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと11');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと12');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと13');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと14');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと15');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと16');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと17');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと18');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと19');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (1, 'testCharacter1', false, null, '1てきすと20');
 
-insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (2, 'testCharacter1', false, null, 'てきすと6');
-insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (2, 'testCharacter1', false, null, 'てきすと7');
-insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (2, 'testCharacter1', false, null, 'てきすと8');
-insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (2, 'testCharacter1', false, null, 'てきすと9');
-insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (2, 'testCharacter1', false, null, 'てきすと10');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (2, 'testCharacter1', false, null, '2てきすと1');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (2, 'testCharacter1', false, null, '2てきすと2');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (2, 'testCharacter1', false, null, '2てきすと3');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (2, 'testCharacter1', false, null, '2てきすと4');
+insert into statuses(world_id, character_id, reply, in_reply_to_id, text) values (2, 'testCharacter1', false, null, '2てきすと5');
 
 # --- !Downs
 delete from statuses;

--- a/conf/routes
+++ b/conf/routes
@@ -19,7 +19,7 @@ POST    /character/:characterId/world/:worldId   controllers.StatusController.cr
 
 GET     /world                      controllers.WorldController.getWorlds
 GET     /world/:id                  controllers.WorldController.find(id: Int)
-GET     /world/:id/status           controllers.StatusController.get(id: Long)
+GET     /world/:id/status/:line           controllers.StatusController.get(id: Long,line:Long)
 POST    /world/:worldId/entry/:characterId                controllers.WorldController.entry(worldId:Long, characterId: String)
 
 #GET     /world/enable               controllers.WorldController.getEnable

--- a/test/controllers/StatusControllerSpec.scala
+++ b/test/controllers/StatusControllerSpec.scala
@@ -39,16 +39,33 @@ class StatusControllerSpec extends ControllerSpecBase {
     "投稿取得" in {
       val request = FakeRequest(GET, "/character/hoge/world/1")
       val controller = new StatusController(stubControllerComponents(), authAction)
-      val result = call(controller.get(1), request)
+      val result = call(controller.get(1, 1), request)
 
       status(result) mustBe OK
-      contentAsString(result) must include("てきすと1")
-      contentAsString(result) must include("てきすと2")
-      contentAsString(result) must include("てきすと3")
+      contentAsString(result) must include("1てきすと1")
+      contentAsString(result) must include("1てきすと2")
+      contentAsString(result) must include("1てきすと3")
+      contentAsString(result) must include("1てきすと4")
+      contentAsString(result) must include("1てきすと5")
+      contentAsString(result) must include("1てきすと6")
+      contentAsString(result) must include("1てきすと7")
+      contentAsString(result) must include("1てきすと8")
+      contentAsString(result) must include("1てきすと9")
+      contentAsString(result) must include("1てきすと10")
+      contentAsString(result) must include("1てきすと11")
+      contentAsString(result) must include("1てきすと12")
+      contentAsString(result) must include("1てきすと13")
+      contentAsString(result) must include("1てきすと14")
+      contentAsString(result) must include("1てきすと15")
+      contentAsString(result) must include("1てきすと16")
+      contentAsString(result) must include("1てきすと17")
+      contentAsString(result) must include("1てきすと18")
+      contentAsString(result) must include("1てきすと19")
+      contentAsString(result) must include("1てきすと20")
 
-      contentAsString(result) mustNot include("てきすと6")
-      contentAsString(result) mustNot include("てきすと7")
-      contentAsString(result) mustNot include("てきすと8")
+      contentAsString(result) mustNot include("2てきすと1")
+      contentAsString(result) mustNot include("2てきすと3")
+      contentAsString(result) mustNot include("2てきすと5")
     }
 
     "キャラクター別投稿一覧取得" in {
@@ -57,15 +74,15 @@ class StatusControllerSpec extends ControllerSpecBase {
       val result = call(controller.getByCharacterId(1, "testCharacter1"), request)
 
       status(result) mustBe OK
-      contentAsString(result) must include("てきすと1")
-      contentAsString(result) must include("てきすと2")
-      contentAsString(result) must include("てきすと3")
-      contentAsString(result) must include("てきすと4")
-      contentAsString(result) must include("てきすと5")
+      contentAsString(result) must include("1てきすと1")
+      contentAsString(result) must include("1てきすと2")
+      contentAsString(result) must include("1てきすと3")
+      contentAsString(result) must include("1てきすと4")
+      contentAsString(result) must include("1てきすと5")
 
-      contentAsString(result) mustNot include("てきすと6")
-      contentAsString(result) mustNot include("てきすと7")
-      contentAsString(result) mustNot include("てきすと8")
+      contentAsString(result) mustNot include("2てきすと1")
+      contentAsString(result) mustNot include("2てきすと3")
+      contentAsString(result) mustNot include("2てきすと5")
 
     }
   }


### PR DESCRIPTION
close #[issues番号]

## 概要

GET     /world/:id/statusを
GET     /world/:id/status/:lineに変更し
投稿を20個ずつ取得するように変更


## 技術的変更点概要



## 今回保留した項目とTODOリスト

testのstatus.sqlの,insertのcreated_at全て一緒なので
21個以上投稿があるとき取得する20個の投稿がランダムになってしまい
取得した20個の投稿を網羅したテストケースが書けなかった


## その他

