### PR TITLE
[fix] 投稿取得を降順に変更

### DIFF
--- a/app/models/repository/StatusRepository.scala
+++ b/app/models/repository/StatusRepository.scala
@@ -142,7 +142,7 @@ object StatusRepositoryImpl extends StatusRepository {
             JOIN characters ch on s.character_id = ch.id
             JOIN creators cr on ch.creator_id = cr.id
             WHERE world_id = ${worldId}
-            ORDER BY created_at
+            ORDER BY id DESC
             LIMIT ${line * 20 - 20}, 20
       """.map(Status.*).list.apply()
 


### PR DESCRIPTION
close #131 

## 概要
* 降順のほうがフロント実装楽そうだったので降順にした
* created_atでソートするのとidでソートするの一緒だと思ったのでidでソートするようにした