### PR TITLE
[update]キャラクター作成時プロフィールとアイコンも追加できるように変更

### DIFF
--- a/app/controllers/CharacterController.scala
+++ b/app/controllers/CharacterController.scala
@@ -49,7 +49,7 @@ class CharacterController @Inject()(cc: ControllerComponents, authAction: AuthAc
       case Failure(e) =>
         BadRequest(e.toVector.asJson)
       case Success(s) =>
-        characterService.create(s.id, s.creatorId, s.name) match {
+        characterService.create(s.id, s.creatorId, s.name, s.profile, s.icon) match {
           case Left(e)  => BadGateway
           case Right(s) => Created(s.asJson)
         }

--- a/app/forms/CharacterForm.scala
+++ b/app/forms/CharacterForm.scala
@@ -3,12 +3,18 @@ package forms
 import forms.validations.{ CharacterValidations, CreatorValidations }
 import scalaz.Scalaz._
 
-case class CharacterCreateForm(id: String, creatorId: String, name: String) {
+case class CharacterCreateForm(id: String,
+                               creatorId: String,
+                               name: String,
+                               profile: Option[String],
+                               icon: Option[String]) {
   def validate() = {
     (
       CharacterValidations.id(this.id) |@|
         CreatorValidations.exists(this.creatorId) |@|
-        CharacterValidations.name(this.name)
+        CharacterValidations.name(this.name) |@|
+        CharacterValidations.profile(this.profile) |@|
+        CharacterValidations.icon(this.icon)
     )(CharacterCreateForm)
   }
 }

--- a/app/forms/validations/CharacterValidations.scala
+++ b/app/forms/validations/CharacterValidations.scala
@@ -41,4 +41,17 @@ object CharacterValidations extends MixInCharacterService with MixInCreatorServi
 
     }
   }
+
+  def profile(profile: Option[String]): ValidationNel[String, Option[String]] = {
+    profile match {
+//      case profile if profile.length >= 100 => "プロフィールが長すぎます".failureNel[Option[String]]
+      case _ => profile.successNel[String]
+    }
+  }
+
+  def icon(icon: Option[String]): ValidationNel[String, Option[String]] = {
+    icon match {
+      case _ => icon.successNel[String]
+    }
+  }
 }

--- a/app/models/repository/CharacterRepository.scala
+++ b/app/models/repository/CharacterRepository.scala
@@ -1,6 +1,5 @@
 package models.repository
 
-import models.entity.Character
 import scalikejdbc._
 
 import scala.util.control.Exception.catching
@@ -26,7 +25,11 @@ trait CharacterRepository {
     * @param s
     * @return
     */
-  def create(id: String, creatorId: String, name: String)(implicit s: DBSession): Try[Long]
+  def create(id: String,
+             creatorId: String,
+             name: String,
+             profile: Option[String],
+             icon: Option[String])(implicit s: DBSession): Try[Long]
   def delete(id: String): Long
   def exists(characterId: String): Boolean
   def getByCreatorId(creatorId: String, line: Long): List[Character]
@@ -73,11 +76,15 @@ object CharacterRepositoryImpl extends CharacterRepository {
     * @param s
     * @return
     */
-  def create(id: String, creatorId: String, name: String)(implicit s: DBSession): Try[Long] =
+  def create(id: String,
+             creatorId: String,
+             name: String,
+             profile: Option[String],
+             icon: Option[String])(implicit s: DBSession): Try[Long] =
     catching(classOf[Throwable]) withTry
       sql"""
-           insert into characters(id,creator_id,name)
-           values (${id},${creatorId}, ${name})
+           insert into characters(id,creator_id,name,profile,icon)
+           values (${id},${creatorId}, ${name},${profile},${icon})
         """.update().apply()
 
   def delete(id: String): Long = {

--- a/app/models/service/CharacterService.scala
+++ b/app/models/service/CharacterService.scala
@@ -28,10 +28,14 @@ trait CharacterService extends UsesCharacterRepository {
     * @param name
     * @return 作成したキャラクター
     */
-  def create(id: String, creatorId: String, name: String): Either[Throwable, Character] =
+  def create(id: String,
+             creatorId: String,
+             name: String,
+             profile: Option[String],
+             icon: Option[String]): Either[Throwable, Character] =
     DB localTx { implicit s =>
       for {
-        _ <- characterRepository.create(id, creatorId, name)
+        _ <- characterRepository.create(id, creatorId, name, profile, icon)
         characterOpt <- characterRepository.find(id)
         character <- Try(characterOpt.get)
       } yield character

--- a/test/controllers/CharacterControllerSpec.scala
+++ b/test/controllers/CharacterControllerSpec.scala
@@ -43,10 +43,22 @@ class CharacterControllerSpec extends ControllerSpecBase {
     }
 
     "キャラクター作成" in {
-
       val request = FakeRequest(POST, "/character")
         .withHeaders("Authorization" -> ("Bearer " + config.get[String]("auth0.token")))
         .withJsonBody(Json.parse("""{ "id": "testchara","creatorId": "hoge", "name": "ほげ"}"""))
+      val controller = new CharacterController(stubControllerComponents(), authAction)
+
+      val result = call(controller.create(), request)
+
+      status(result) mustBe CREATED
+      contentAsString(result) must include("testchara")
+    }
+
+    "キャラクター作成(profile,iconアリ)" in {
+      val request = FakeRequest(POST, "/character")
+        .withHeaders("Authorization" -> ("Bearer " + config.get[String]("auth0.token")))
+        .withJsonBody(Json.parse(
+          """{ "id": "testcharaProIco","creatorId": "hoge", "name": "ほげ","profile":"プロフィールとアイコンあるよ","icon":"アイコン"}"""))
       val controller = new CharacterController(stubControllerComponents(), authAction)
 
       val result = call(controller.create(), request)

--- a/test/mocks/ErrorCharacterService.scala
+++ b/test/mocks/ErrorCharacterService.scala
@@ -18,7 +18,11 @@ object ErrorCharacterRepositoryImpl extends CharacterRepository {
   def find(id: String)(implicit s: DBSession): Try[Option[Character]] =
     Try(throw new Exception)
 
-  def create(id: String, creatorId: String, name: String)(implicit s: DBSession): Try[Long] =
+  def create(id: String,
+             creatorId: String,
+             name: String,
+             profile: Option[String],
+             icon: Option[String])(implicit s: DBSession): Try[Long] =
     Try(throw new Exception)
 
   def delete(id: String): Long = throw new Exception

--- a/test/mocks/MockCharacterService.scala
+++ b/test/mocks/MockCharacterService.scala
@@ -42,7 +42,11 @@ object MockCharacterRepositoryImpl extends CharacterRepository {
           ZonedDateTime.now()
         )))
 
-  def create(id: String, creatorId: String, name: String)(implicit s: DBSession): Try[Long] =
+  def create(id: String,
+             creatorId: String,
+             name: String,
+             profile: Option[String],
+             icon: Option[String])(implicit s: DBSession): Try[Long] =
     Try(1)
 
   def delete(id: String): Long = 1


### PR DESCRIPTION
close #138 

## 概要

キャラクター作成時にプロフィールとアイコンがあってもなくても作成できるようにした

## 技術的変更点概要

## 今回保留した項目とTODOリスト

## その他
